### PR TITLE
try to protect fish7 from the crab

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,7 @@
             #fish5 { color: green; animation-delay: 0.8s; }
             #fish6 { color: gold; animation-delay: 1.8s; }
             #fish7 { color: brown; animation-delay: 0.6s; }
+            #no-swim-zone { background-color: aqua; height: 2em; position: absolute; bottom: 2em; width: 100%; }
             #crab  { color: red; position: absolute; bottom: 2em; width: 100%; }
         </style>
     </head>
@@ -50,7 +51,7 @@
                 <marquee id="fish5" direction="right" scrollamount=5>&gt;&lt;&gt;</marquee>
                 <marquee id="fish6" scrollamount=6>&lt;&gt;&lt;</marquee>
                 <marquee id="fish7" direction="right" scrollamount=8>&gt;&lt;&gt;</marquee>
-                <br><br>
+                <div id="no-swim-zone"></div>
                 <marquee id="crab" behavior="alternate" scrollamount="4"> (\/)O_o(\/) </marquee>
             </div>
             <div id="sand">&nbsp;</div>


### PR DESCRIPTION
It's currently possible for the bottom fish (so-called `fish7`) to get snagged by the crab if you make your browser window very short. This is because I added the sand and moved the crab up.

I regret nothing! But I do want to keep the fish out of danger.

This kind of works, but instead of the fish touching the crab

![poor fish7](https://cloud.githubusercontent.com/assets/597/13416589/feef3566-df31-11e5-8dc9-2e2446995913.gif)

the fish will disappear

![disappearing fish7](https://cloud.githubusercontent.com/assets/597/13416594/0ad69a7c-df32-11e5-86e9-60c8a3194d4d.gif)


And in Safari, the crab has disappeared:

![no crab safari](https://cloud.githubusercontent.com/assets/597/13416639/4cd6940e-df32-11e5-9b3d-b9fabf04e408.gif)